### PR TITLE
max_pages argument fixes #43 to limit search size

### DIFF
--- a/R/search-source.R
+++ b/R/search-source.R
@@ -88,9 +88,10 @@ ss_initialize <- function(self, private, src_params) {
 #' @return Search response after parsing
 #' @export
 #'
-ss_search <- function(query, solr.url, solr.auth.user = NULL,
-                      solr.auth.pwd = NULL, source,
-                      sortby, orderby, start = 0, pagesize = 10,
+ss_search <- function(query,
+                      solr.url, solr.auth.user = NULL, solr.auth.pwd = NULL,
+                      source, sortby, orderby,
+                      start = 0, pagesize = 10, max_pages = 20,
                       group.limit = 4,  hl.fragsize=60) {
 
   ## FIXME: The Query comes URL encoded. From the search box? Replace all spaces with +
@@ -98,9 +99,13 @@ ss_search <- function(query, solr.url, solr.auth.user = NULL,
   ## DOUG Move this up to controller?
   if(nchar(query) > nchar(utils::URLdecode(query))) query <- utils::URLdecode(query)
 
+  rows <- max(pagesize * max_pages, 10)
+
+  message("hello", pagesize, " ", max_pages)
+
   solr.query <- list(q=query,
                      start=start,
-                     rows=pagesize,
+                     rows=rows,
                      indent="true",
                      group="true",
                      group.field="notebook_id",

--- a/R/search.R
+++ b/R/search.R
@@ -10,6 +10,7 @@
 #' @param orderby Passed to solr for sorting
 #' @param start Passed to solr
 #' @param pagesize Passed to solr
+#' @param max_pages Sets the size of search
 #' @param group.limit Passed to solr. Controls how many cells to highlight for each notebook hit.
 #' @param hl.fragsize How many characters to return with the highlighting
 #'
@@ -23,6 +24,7 @@ rcloud.search <-
            orderby = "desc",
            start = 0,
            pagesize = 10,
+           max_pages = 20,
            group.limit = 4,
            hl.fragsize = 60) {
     .SC$search(
@@ -32,6 +34,7 @@ rcloud.search <-
       orderby = orderby,
       start = start,
       pagesize = pagesize,
+      max_pages = max_pages,
       group.limit = group.limit,
       hl.fragsize = hl.fragsize
     )

--- a/man/rcloud.search.Rd
+++ b/man/rcloud.search.Rd
@@ -5,8 +5,8 @@
 \title{Search RCloud Notebooks}
 \usage{
 rcloud.search(query, all_sources = FALSE, sortby = "starcount",
-  orderby = "desc", start = 0, pagesize = 10, group.limit = 4,
-  hl.fragsize = 60)
+  orderby = "desc", start = 0, pagesize = 10, max_pages = 20,
+  group.limit = 4, hl.fragsize = 60)
 }
 \arguments{
 \item{query}{Search string}
@@ -20,6 +20,8 @@ rcloud.search(query, all_sources = FALSE, sortby = "starcount",
 \item{start}{Passed to solr}
 
 \item{pagesize}{Passed to solr}
+
+\item{max_pages}{Sets the size of search}
 
 \item{group.limit}{Passed to solr. Controls how many cells to highlight for each notebook hit.}
 

--- a/man/ss_search.Rd
+++ b/man/ss_search.Rd
@@ -5,8 +5,8 @@
 \title{Search a single source}
 \usage{
 ss_search(query, solr.url, solr.auth.user = NULL, solr.auth.pwd = NULL,
-  source, sortby, orderby, start = 0, pagesize = 10, group.limit = 4,
-  hl.fragsize = 60)
+  source, sortby, orderby, start = 0, pagesize = 10, max_pages = 20,
+  group.limit = 4, hl.fragsize = 60)
 }
 \arguments{
 \item{query}{Search string}
@@ -26,6 +26,8 @@ ss_search(query, solr.url, solr.auth.user = NULL, solr.auth.pwd = NULL,
 \item{start}{Passed to solr}
 
 \item{pagesize}{Passed to solr}
+
+\item{max_pages}{Sets the size of search}
 
 \item{group.limit}{Passed to solr. Controls how many cells to highlight for each notebook hit.}
 

--- a/tests/testthat/test-searchcontroller.R
+++ b/tests/testthat/test-searchcontroller.R
@@ -81,8 +81,8 @@ test_that("Global search instance exists", {
 
 test_that("New search two sources", {
 
-  skipifnot(check_solr_instance("http://solr"))
-  skipifnot(check_solr_instance("http://solr2"))
+  skip_if_not(check_solr_instance("http://solr"))
+  skip_if_not(check_solr_instance("http://solr2"))
 
   sources <- read_rcloud_conf("rc-two.conf")
 
@@ -115,8 +115,8 @@ test_that("New search two sources", {
 
 test_that("Full search two sources", {
 
-  skipifnot(check_solr_instance("http://solr"))
-  skipifnot(check_solr_instance("http://solr2"))
+  skip_if_not(check_solr_instance("http://solr"))
+  skip_if_not(check_solr_instance("http://solr2"))
 
   sources <- read_rcloud_conf("rc-two.conf")
 

--- a/tests/testthat/test-searchcontroller.R
+++ b/tests/testthat/test-searchcontroller.R
@@ -81,6 +81,9 @@ test_that("Global search instance exists", {
 
 test_that("New search two sources", {
 
+  skipifnot(check_solr_instance("http://solr"))
+  skipifnot(check_solr_instance("http://solr2"))
+
   sources <- read_rcloud_conf("rc-two.conf")
 
   SC <- SearchController$new(sources = sources)
@@ -106,7 +109,33 @@ test_that("New search two sources", {
   results <- SC$get_results()
 
   expect_named(results, c("header", "notebooks"))
-  expect_equal(length(results$notebooks), 20)
+  expect_equal(length(results$notebooks), 24)
 
 })
 
+test_that("Full search two sources", {
+
+  skipifnot(check_solr_instance("http://solr"))
+  skipifnot(check_solr_instance("http://solr2"))
+
+  sources <- read_rcloud_conf("rc-two.conf")
+
+  SC <- SearchController$new(sources = sources)
+
+  response <- SC$search(
+    "hist",
+    all_sources = TRUE,
+    sortby = "starcount",
+    orderby = "desc",
+    start = 0,
+    pagesize = 10,
+    max_pages = 10,
+    group.limit = 4
+  )
+
+  expect_equal(response$n_notebooks, 24)
+  expect_equal(length(response$notebooks), 10)
+  # Check the sort order (roughly)
+  expect_gte(response$notebooks[[1]]$starcount,
+             response$notebooks[[2]]$starcount)
+})


### PR DESCRIPTION
Number of rows pulled from each solr source is pagesize * max_pages. The default is `max_pages = 20` and `pagesize = 10` which means that 200 results could come back per source.